### PR TITLE
Add MLIR packages install in CI

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install MLIR dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libmlir-16-dev mlir-tools
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type


### PR DESCRIPTION
## Summary
- install `libmlir-16-dev` and `mlir-tools` in CI

## Testing
- `cmake ..` *(fails: Could not find MLIRConfig.cmake)*